### PR TITLE
Delete robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
I assume this file was originally put here to make sure that the github.io site didn't get indexed by Google. Now that the site is live though, it should be removed to allow search engines to index the site.
