### PR TITLE
Always set `site.title` in page title

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/static/img/favicon.ico">
 
     {% if page.title %}
-      <title>{{ page.title }}</title>
+      <title>{{ page.title }} - {{ site.title }}</title>
     {% else %}
       <title>{{ site.title }}</title>
     {% endif %}


### PR DESCRIPTION
When RES is updated it automatically opens a background tab called "Releases".

It'd be useful to know what this page is, so this commit changes the title to "Releases - Reddit Enhancement Suite".
