### PR TITLE
Add Safari auto-update manifest

### DIFF
--- a/update-safari.plist
+++ b/update-safari.plist
@@ -13,7 +13,7 @@
        <key>CFBundleShortVersionString</key>
        <string>5.0.2</string>
        <key>URL</key>
-       <string>http://redditenhancementsuite.com/static/downloads/RES.safariextz</string>
+       <string>https://redditenhancementsuite.com/static/downloads/RES.safariextz</string>
      </dict>
    </array>
 </dict>

--- a/update-safari.plist
+++ b/update-safari.plist
@@ -1,0 +1,20 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>Extension Updates</key>
+   <array>
+     <dict>
+       <key>CFBundleIdentifier</key>
+       <string>com.honestbleeps.redditenhancementsuite</string>
+       <key>Developer Identifier</key>
+       <string>63DT2C85Z6</string>
+       <key>CFBundleVersion</key>
+       <string>5.0.2</string>
+       <key>CFBundleShortVersionString</key>
+       <string>5.0.2</string>
+       <key>URL</key>
+       <string>http://redditenhancementsuite.com/static/downloads/RES.safariextz</string>
+     </dict>
+   </array>
+</dict>
+</plist>


### PR DESCRIPTION
This hopefully will make Safari auto-upgrade everyone to RES v5.0.2 over the next day or so.
